### PR TITLE
add renderer to same network as grafana

### DIFF
--- a/services-monitoring/docker-compose.yml
+++ b/services-monitoring/docker-compose.yml
@@ -40,6 +40,8 @@ services:
 
   renderer:
     image: grafana/grafana-image-renderer:latest
+    networks:
+      - services-monitoring_default
 
   loki:
     image: grafana/loki:2.6.1


### PR DESCRIPTION
I'm gettting error:
```
logger=rendering renderer=http t=2023-08-13T12:19:49.080500174Z level=error msg="Failed to send request to remote rendering service" error="Get \"http://renderer:8081/render?deviceScaleFactor=1.000000&domain=grafana&encoding=&height=500&renderKey=fYXkQRO6RzA5xhDSYuf6nGdQ9W5xDAis&timeout=60&timezone=Europe%2FWarsaw&url=http%3A%2F%2Fgrafana%3A3000%2Fd-solo%2Fefd454c7-2714-4507-b5b5-188e1feceeb7%2Fpublic-network-stats%3ForgId%3D1%26from%3D1691756388001%26to%3D1691929188001%26panelId%3D2%26width%3D1000%26height%3D500%26tz%3DEurope%252FWarsaw%26render%3D1&width=1000\": dial tcp: lookup renderer on 127.0.0.11:53: no such host"
```