### PR TITLE
pass minio address in proper manner

### DIFF
--- a/minio/docker-compose.yml
+++ b/minio/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - minio
       - system_default
     image: quay.io/minio/minio:RELEASE.2023-08-16T20-17-30Z
-    command: server https://static.apps.hskrk.pl/data --console-address ":9001"
+    command: server /data --address "static.apps.hskrk.pl" --console-address ":9001"
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}


### PR DESCRIPTION
Currently it's dying:
```
ERROR Invalid command line arguments: use path style endpoint for single node setup

      > Please check the endpoint

      HINT:

        Single-Node modes requires absolute path without hostnames:

      Examples:

         $ minio server /data/minio/ #Single Node Single Drive

         $ minio server /data-{1...4}/minio # Single Node Multi Drive
```