### PR TITLE
fix: Increase DB start period for Authentik

### DIFF
--- a/system/docker-compose.yml
+++ b/system/docker-compose.yml
@@ -126,7 +126,7 @@ services:
     image: pgautoupgrade/pgautoupgrade:${POSTGRES_TAG:-12-alpine}
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}" ]
-      start_period: 20s
+      start_period: 2m
       interval: 30s
       retries: 5
       timeout: 5s


### PR DESCRIPTION
When DB is upgrading from the previous version, it may take a while for healthchecks to pass. We don't want any restarts to be triggered in this period. Increased the startup time to 2 minutes to avoid that