### PR TITLE
Update loki and promatil to 3.5.5, update config, add network aliases

### DIFF
--- a/services-monitoring/docker-compose.yml
+++ b/services-monitoring/docker-compose.yml
@@ -48,9 +48,16 @@ services:
       - RENDERING_MODE=reusable
 
   loki:
-    image: grafana/loki:2.6.1
+    image: grafana/loki:3.5.5
     networks:
-      - services-monitoring_default
+      services-monitoring_default:
+        aliases:
+          - push.loki
+          - backend.loki
+      system_default:
+        aliases:
+          - query.loki
+          - frontend.loki
     restart: always
     user: "0"
     command: -config.file=/etc/loki/local-config.yaml
@@ -65,7 +72,8 @@ services:
         - "traefik.http.routers.loki.rule=Host(`loki.apps.hskrk.pl`)"
         - "traefik.http.routers.loki.tls=true"
         - "traefik.http.routers.loki.tls.certresolver=myresolver"
-        - "traefik.http.middlewares.loki.ipallowlist.sourcerange=127.0.0.1/32, 10.12.20.9/32"
+        - "traefik.http.routers.loki.middlewares=loki@docker"
+        - "traefik.http.middlewares.loki.ipallowlist.sourcerange=10.12.20.9,10.0.0.0/16,45.66.23.240/29,127.0.0.0/16"
 
   prometheus:
     secrets:
@@ -186,7 +194,7 @@ services:
       retries: 3
 
   promtail:
-    image: grafana/promtail:2.6.1
+    image: grafana/promtail:3.5.5
     networks:
       - services-monitoring_default
     restart: unless-stopped

--- a/services-monitoring/loki/config/config.yml
+++ b/services-monitoring/loki/config/config.yml
@@ -19,7 +19,6 @@ ingester:
   max_chunk_age: 1h # All chunks will be flushed when they hit this age, default is 1h
   chunk_target_size: 1048576 # Loki will attempt to build chunks up to 1.5MB, flushing first if chunk_idle_period or max_chunk_age is reached first
   chunk_retain_period: 30s # Must be greater than index read cache TTL if using an index cache (Default index read cache TTL is 5m)
-  max_transfer_retries: 0 # Chunk transfers disabled
 
 schema_config:
   configs:
@@ -30,26 +29,30 @@ schema_config:
       index:
         prefix: index_
         period: 24h
+    - from: 2025-10-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
 
 storage_config:
   tsdb_shipper:
     active_index_directory: /data/tsdb-index
     cache_location: /data/tsdb-cache
     cache_ttl: 24h # Can be increased for faster performance over longer query periods, uses more disk space
-    shared_store: filesystem
   filesystem:
     directory: /data/chunks
 
 compactor:
   working_directory: /data/retention
-  shared_store: filesystem
 
 limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
-
-chunk_store_config:
-  max_look_back_period: 0s
+  allow_structured_metadata: false
 
 table_manager:
   retention_deletes_enabled: true


### PR DESCRIPTION
Old config was incompatible with loki 3.x, older loki couldn't connect with grafana.
2 networks common with grafana needs aliases to proper DNS resolving connection host.